### PR TITLE
chore: initialize monorepo with auth base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env
+*.log
+dist
+dev.db
+prisma/dev.db
+.next
+out
+coverage
+.DS_Store

--- a/Backlog.md
+++ b/Backlog.md
@@ -1,0 +1,117 @@
+# Product Backlog – AMIT-PMS (MVP)
+
+---
+
+## Epic: Authentication & Tenancy
+
+**User Story:** כ–משתמש, אני רוצה להתחבר למערכת לפי תפקיד (דייר, מנהל, טכנאי, רו"ח).
+
+- [x] Task 1: Implement JWT-based Auth (short-lived + refresh tokens).
+- [x] Task 2: Create User model with role & tenant_id.
+- [ ] Task 3: Add RBAC middleware (admin/pm/tech/resident/accountant).
+- [ ] Task 4: Setup RLS (Row-Level Security) in Postgres by tenant_id.
+
+**Acceptance:** משתמש נכנס ורואה רק את המידע של הטננט שלו לפי הרשאה.
+
+---
+
+## Epic: Buildings & Residents
+
+**User Story:** כ–מנהל, אני רוצה לנהל בניינים, דירות ודיירים.
+
+- [ ] Task 1: Create Building, Unit, Resident models.
+- [ ] Task 2: CRUD endpoints: /api/v1/buildings, /api/v1/units.
+- [ ] Task 3: Associate residents with units (many-to-many).
+- [ ] Task 4: Seed demo building with test data.
+
+**Acceptance:** מנהל יכול להוסיף בניין, יחידות ודיירים; דייר רואה רק את יחידתו.
+
+---
+
+## Epic: Tickets (קריאות שירות)
+
+**User Story:** כ–דייר, אני רוצה לפתוח קריאת שירות עם תיאור ותמונה.
+
+- [ ] Task 1: Create Ticket model (id, unit_id, severity, status, sla_due, photos[]).
+- [ ] Task 2: Endpoint POST /api/v1/tickets (with photo upload → S3).
+- [ ] Task 3: Endpoint GET /api/v1/tickets?status&buildingId.
+- [ ] Task 4: Manager dashboard: assign ticket to supplier/tech.
+- [ ] Task 5: Notifications on status change (email/push).
+
+**Acceptance:** דייר פותח קריאה → מופיעה לדשבורד המנהל → מוקצת לטכנאי → נסגרת.
+
+---
+
+## Epic: Suppliers & Work Orders
+
+**User Story:** כ–מנהל, אני רוצה להקצות קריאות שירות לטכנאי או ספק.
+
+- [ ] Task 1: Create Supplier model (skills[], rating, documents).
+- [ ] Task 2: Create WorkOrder model (ticket_id, supplier_id, cost_estimate).
+- [ ] Task 3: Endpoint PATCH /api/v1/tickets/{id}/assign.
+- [ ] Task 4: Tech mobile view: list of today’s jobs + update status.
+
+**Acceptance:** מנהל מקצה תקלה לספק; ספק רואה אותה באפליקציה וסוגר עם תמונה.
+
+---
+
+## Epic: Payments & Billing
+
+**User Story:** כ–דייר, אני רוצה לשלם אונליין ולקבל קבלה במייל.
+
+- [ ] Task 1: Create Invoice model (debtor_id, items[], status).
+- [ ] Task 2: Integrate with Tranzila sandbox API.
+- [ ] Task 3: Webhook endpoint for payment confirmation.
+- [ ] Task 4: PDF receipt generation (SendGrid or SES).
+- [ ] Task 5: Dashboard: unpaid invoices list + filter.
+
+**Acceptance:** דייר מקבל לינק תשלום → משלם → קבלה נשלחת למייל.
+
+---
+
+## Epic: Notifications & Communication
+
+**User Story:** כ–מנהל, אני רוצה לשלוח הודעות לדיירים/בניינים.
+
+- [ ] Task 1: Notification service (to: user/building/all tenants).
+- [ ] Task 2: Channels: Email (SendGrid), Push (PWA), SMS (Twilio).
+- [ ] Task 3: Templates for status updates & general announcements.
+
+**Acceptance:** דייר מקבל הודעת "קריאה נפתרה" + יכולת למנהל לשלוח עדכון לכל בניין.
+
+---
+
+## Epic: Dashboard & Reporting
+
+**User Story:** כ–מנהל, אני רוצה לראות סטטוס כולל של תקלות ותשלומים.
+
+- [ ] Task 1: Build dashboard with KPIs (open tickets, SLA breaches, unpaid invoices).
+- [ ] Task 2: Add search/filter bar for quick lookup.
+- [ ] Task 3: Export CSV/Excel for accountant.
+
+**Acceptance:** מנהל רואה בלוח בקרה תמונה מלאה ומבצע חיתוכים לפי בניין/סטטוס.
+
+---
+
+## Epic: Non-Functional (NFRs)
+
+**User Story:** כ–מנהל מערכת, אני רוצה שהמערכת תהיה מאובטחת ונגישה.
+
+- [ ] Task 1: Add MFA for admin login.
+- [ ] Task 2: WCAG 2.1 AA accessibility for web.
+- [ ] Task 3: Structured logging (JSON logs + correlation IDs).
+- [ ] Task 4: Monitoring (Prometheus + Grafana).
+- [ ] Task 5: Backups & restore test.
+
+**Acceptance:** אבטחת מידע עומדת ב-OWASP ASVS L2, המערכת זמינה ב-99.9%.
+
+---
+
+## Sprint Plan 
+
+- **Sprint 0**: Repo setup (monorepo, Next.js + NestJS, auth base, DB seed).
+- **Sprint 1**: Tickets module (end-to-end).
+- **Sprint 2**: Payments basic flow.
+- **Sprint 3**: Dashboard + Notifications.
+- **Sprint 4**: Hardening (NFRs, polish, MFA, backups).
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# AMS
+# AMIT-PMS
+
+Monorepo for AMIT Property Management System.
+
+## Apps
+- `apps/backend`: NestJS API server.
+- `apps/frontend`: Next.js web application.
+
+## Development
+```
+npm install
+npm run dev:backend
+npm run dev:frontend
+```

--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@amit-pms/backend",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "ts-node src/main.ts",
+    "prisma:seed": "ts-node prisma/seed.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/jwt": "^10.0.0",
+    "@nestjs/passport": "^10.0.0",
+    "passport": "^0.6.0",
+    "passport-jwt": "^4.0.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "bcrypt": "^5.1.0",
+    "@prisma/client": "^5.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.9.1",
+    "prisma": "^5.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
+  }
+}

--- a/apps/backend/prisma/migrations/20231011100000_init/migration.sql
+++ b/apps/backend/prisma/migrations/20231011100000_init/migration.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "User" (
+    "id" SERIAL PRIMARY KEY,
+    "email" VARCHAR(255) UNIQUE NOT NULL,
+    "passwordHash" VARCHAR(255) NOT NULL,
+    "tenantId" INTEGER NOT NULL,
+    "role" VARCHAR(20) NOT NULL,
+    "refreshTokenHash" VARCHAR(255),
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,0 +1,26 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum Role {
+  ADMIN
+  PM
+  TECH
+  RESIDENT
+  ACCOUNTANT
+}
+
+model User {
+  id            Int      @id @default(autoincrement())
+  email         String   @unique
+  passwordHash  String
+  tenantId      Int
+  role          Role
+  refreshTokenHash String?
+  createdAt     DateTime @default(now())
+}

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,0 +1,22 @@
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const passwordHash = await bcrypt.hash('admin123', 10);
+  await prisma.user.upsert({
+    where: { email: 'admin@demo.com' },
+    update: {},
+    create: {
+      email: 'admin@demo.com',
+      passwordHash,
+      role: 'ADMIN',
+      tenantId: 1,
+    },
+  });
+}
+
+main().finally(async () => {
+  await prisma.$disconnect();
+});

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from './auth/auth.module';
+import { UserModule } from './users/user.module';
+
+@Module({
+  imports: [AuthModule, UserModule],
+})
+export class AppModule {}

--- a/apps/backend/src/auth/__tests__/auth.service.spec.ts
+++ b/apps/backend/src/auth/__tests__/auth.service.spec.ts
@@ -1,0 +1,32 @@
+import { AuthService } from '../auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { UserService } from '../../users/user.service';
+import * as bcrypt from 'bcrypt';
+
+describe('AuthService', () => {
+  const userService: Partial<UserService> = {
+    findByEmail: jest.fn(async (email: string) => {
+      if (email === 'test@example.com') {
+        return {
+          id: 1,
+          email,
+          passwordHash: await bcrypt.hash('password', 10),
+          tenantId: 1,
+          role: 'RESIDENT',
+        } as any;
+      }
+      return null;
+    }),
+  };
+  const jwtService = new JwtService({ secret: 'test' });
+  const service = new AuthService(userService as UserService, jwtService);
+
+  it('validates user credentials', async () => {
+    const user = await service.validateUser('test@example.com', 'password');
+    expect(user.email).toBe('test@example.com');
+  });
+
+  it('throws on invalid credentials', async () => {
+    await expect(service.validateUser('test@example.com', 'wrong')).rejects.toBeDefined();
+  });
+});

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+import * as bcrypt from 'bcrypt';
+import { UserService } from '../users/user.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private auth: AuthService, private users: UserService) {}
+
+  @Post('login')
+  async login(@Body() dto: LoginDto) {
+    const user = await this.auth.validateUser(dto.email, dto.password);
+    return this.auth.login(user);
+  }
+
+  @Post('signup')
+  async signup(@Body() dto: LoginDto) {
+    const hash = await bcrypt.hash(dto.password, 10);
+    const user = await this.users.create({
+      email: dto.email,
+      passwordHash: hash,
+      role: 'RESIDENT',
+      tenantId: 1,
+    });
+    return this.auth.login(user);
+  }
+}

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { UserModule } from '../users/user.module';
+import { JwtAccessStrategy } from './strategies/jwt-access.strategy';
+import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
+
+@Module({
+  imports: [
+    UserModule,
+    PassportModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'secret',
+      signOptions: { expiresIn: '15m' },
+    }),
+  ],
+  providers: [AuthService, JwtAccessStrategy, JwtRefreshStrategy],
+  controllers: [AuthController],
+})
+export class AuthModule {}

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { UserService } from '../users/user.service';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class AuthService {
+  constructor(private users: UserService, private jwt: JwtService) {}
+
+  async validateUser(email: string, password: string) {
+    const user = await this.users.findByEmail(email);
+    if (!user) throw new UnauthorizedException('Invalid credentials');
+    const match = await bcrypt.compare(password, user.passwordHash);
+    if (!match) throw new UnauthorizedException('Invalid credentials');
+    return user;
+  }
+
+  async login(user: { id: number; email: string; role: string; tenantId: number }) {
+    const payload = { sub: user.id, role: user.role, tenantId: user.tenantId };
+    const accessToken = await this.jwt.signAsync(payload, { expiresIn: '15m' });
+    const refreshToken = await this.jwt.signAsync(payload, { expiresIn: '7d' });
+    return { accessToken, refreshToken };
+  }
+}

--- a/apps/backend/src/auth/dto/login.dto.ts
+++ b/apps/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,10 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/apps/backend/src/auth/jwt-auth.guard.ts
+++ b/apps/backend/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/apps/backend/src/auth/strategies/jwt-access.strategy.ts
+++ b/apps/backend/src/auth/strategies/jwt-access.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtAccessStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_SECRET || 'secret',
+    });
+  }
+
+  validate(payload: any) {
+    return payload;
+  }
+}

--- a/apps/backend/src/auth/strategies/jwt-refresh.strategy.ts
+++ b/apps/backend/src/auth/strategies/jwt-refresh.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_REFRESH_SECRET || 'refresh_secret',
+    });
+  }
+
+  validate(payload: any) {
+    return payload;
+  }
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,0 +1,10 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/backend/src/prisma.service.ts
+++ b/apps/backend/src/prisma.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  async onModuleInit() {
+    await this.$connect();
+  }
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/apps/backend/src/users/user.module.ts
+++ b/apps/backend/src/users/user.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './user.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  providers: [PrismaService, UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/apps/backend/src/users/user.service.ts
+++ b/apps/backend/src/users/user.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { Prisma, User } from '@prisma/client';
+
+@Injectable()
+export class UserService {
+  constructor(private prisma: PrismaService) {}
+
+  findByEmail(email: string) {
+    return this.prisma.user.findUnique({ where: { email } });
+  }
+
+  create(data: Prisma.UserCreateInput): Promise<User> {
+    return this.prisma.user.create({ data });
+  }
+}

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "prisma/**/*"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+}
+module.exports = nextConfig

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@amit-pms/frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/frontend/pages/index.tsx
+++ b/apps/frontend/pages/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Home() {
+  return <main>AMIT-PMS frontend</main>;
+}

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "amit-pms",
+  "private": true,
+  "workspaces": [
+    "apps/backend",
+    "apps/frontend"
+  ],
+  "scripts": {
+    "dev:backend": "npm --workspace apps/backend run start:dev",
+    "dev:frontend": "npm --workspace apps/frontend run dev",
+    "test": "echo 'No tests yet'"
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js + NestJS monorepo
- add JWT auth with login/signup endpoints
- define Prisma User model with tenant and role

## Testing
- `npm test`
- `npm --workspace apps/backend test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ecde365c8329a1eafbf35a1ecb53