### PR TITLE
feat: add RBAC guard and tenant RLS

### DIFF
--- a/Backlog.md
+++ b/Backlog.md
@@ -8,8 +8,8 @@
 
 - [x] Task 1: Implement JWT-based Auth (short-lived + refresh tokens).
 - [x] Task 2: Create User model with role & tenant_id.
-- [ ] Task 3: Add RBAC middleware (admin/pm/tech/resident/accountant).
-- [ ] Task 4: Setup RLS (Row-Level Security) in Postgres by tenant_id.
+- [x] Task 3: Add RBAC middleware (admin/pm/tech/resident/accountant).
+- [x] Task 4: Setup RLS (Row-Level Security) in Postgres by tenant_id.
 
 **Acceptance:** משתמש נכנס ורואה רק את המידע של הטננט שלו לפי הרשאה.
 

--- a/apps/backend/prisma/migrations/20231011120000_rls/migration.sql
+++ b/apps/backend/prisma/migrations/20231011120000_rls/migration.sql
@@ -1,0 +1,6 @@
+-- Enable row level security on User table
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+
+-- Policy to allow users to access only rows from their tenant
+CREATE POLICY user_tenant_isolation ON "User"
+  USING ("tenantId" = current_setting('app.tenant_id')::int);

--- a/apps/backend/src/auth/jwt-auth.guard.ts
+++ b/apps/backend/src/auth/jwt-auth.guard.ts
@@ -1,5 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { PrismaService } from '../prisma.service';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private prisma: PrismaService) {
+    super();
+  }
+
+  async handleRequest(err: any, user: any, info: any, context: any, status?: any) {
+    if (user?.tenantId) {
+      await this.prisma.$executeRaw`SET app.tenant_id = ${user.tenantId}`;
+    }
+    return super.handleRequest(err, user, info, context, status);
+  }
+}

--- a/apps/backend/src/auth/roles.decorator.ts
+++ b/apps/backend/src/auth/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '@prisma/client';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/backend/src/auth/roles.guard.ts
+++ b/apps/backend/src/auth/roles.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '@prisma/client';
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user?.role);
+  }
+}

--- a/apps/backend/src/users/user.controller.ts
+++ b/apps/backend/src/users/user.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { UserService } from './user.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+
+@Controller('users')
+export class UserController {
+  constructor(private users: UserService) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.ADMIN)
+  findAll() {
+    return this.users.findAll();
+  }
+}

--- a/apps/backend/src/users/user.module.ts
+++ b/apps/backend/src/users/user.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { PrismaService } from '../prisma.service';
+import { UserController } from './user.controller';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
 
 @Module({
-  providers: [PrismaService, UserService],
-  exports: [UserService],
+  providers: [PrismaService, UserService, JwtAuthGuard, RolesGuard],
+  controllers: [UserController],
+  exports: [UserService, PrismaService],
 })
 export class UserModule {}

--- a/apps/backend/src/users/user.service.ts
+++ b/apps/backend/src/users/user.service.ts
@@ -13,4 +13,8 @@ export class UserService {
   create(data: Prisma.UserCreateInput): Promise<User> {
     return this.prisma.user.create({ data });
   }
+
+  findAll(): Promise<User[]> {
+    return this.prisma.user.findMany();
+  }
 }


### PR DESCRIPTION
## Summary
- add role-based authorization guard and decorator
- enforce tenant isolation using Postgres RLS and session variable
- expose admin-only user listing endpoint

## Testing
- `npm test`
- `npm --workspace apps/backend test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9013ba30083299e0ab59a43cfa6b2