### PR TITLE
feat: add building and unit management

### DIFF
--- a/Backlog.md
+++ b/Backlog.md
@@ -19,10 +19,10 @@
 
 **User Story:** כ–מנהל, אני רוצה לנהל בניינים, דירות ודיירים.
 
-- [ ] Task 1: Create Building, Unit, Resident models.
-- [ ] Task 2: CRUD endpoints: /api/v1/buildings, /api/v1/units.
-- [ ] Task 3: Associate residents with units (many-to-many).
-- [ ] Task 4: Seed demo building with test data.
+ - [x] Task 1: Create Building, Unit, Resident models.
+ - [x] Task 2: CRUD endpoints: /api/v1/buildings, /api/v1/units.
+ - [x] Task 3: Associate residents with units (many-to-many).
+ - [x] Task 4: Seed demo building with test data.
 
 **Acceptance:** מנהל יכול להוסיף בניין, יחידות ודיירים; דייר רואה רק את יחידתו.
 

--- a/apps/backend/prisma/migrations/20231011130000_buildings/migration.sql
+++ b/apps/backend/prisma/migrations/20231011130000_buildings/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "Building" (
+    "id" SERIAL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "tenantId" INTEGER NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Unit" (
+    "id" SERIAL PRIMARY KEY,
+    "number" TEXT NOT NULL,
+    "buildingId" INTEGER NOT NULL REFERENCES "Building"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Resident" (
+    "id" SERIAL PRIMARY KEY,
+    "userId" INTEGER NOT NULL UNIQUE REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable (implicit many-to-many)
+CREATE TABLE "_ResidentToUnit" (
+    "A" INTEGER NOT NULL REFERENCES "Resident"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    "B" INTEGER NOT NULL REFERENCES "Unit"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ResidentToUnit_AB_unique" ON "_ResidentToUnit"("A", "B");
+CREATE INDEX "_ResidentToUnit_B_index" ON "_ResidentToUnit"("B");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -23,4 +23,28 @@ model User {
   role          Role
   refreshTokenHash String?
   createdAt     DateTime @default(now())
+  resident      Resident?
+}
+
+model Building {
+  id        Int     @id @default(autoincrement())
+  name      String
+  address   String
+  tenantId  Int
+  units     Unit[]
+}
+
+model Unit {
+  id         Int        @id @default(autoincrement())
+  number     String
+  buildingId Int
+  building   Building   @relation(fields: [buildingId], references: [id])
+  residents  Resident[]
+}
+
+model Resident {
+  id      Int    @id @default(autoincrement())
+  userId  Int    @unique
+  user    User   @relation(fields: [userId], references: [id])
+  units   Unit[]
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -15,6 +15,59 @@ async function main() {
       tenantId: 1,
     },
   });
+
+  await prisma.resident.deleteMany();
+  await prisma.unit.deleteMany();
+  await prisma.building.deleteMany();
+  await prisma.user.deleteMany({ where: { role: 'RESIDENT' } });
+
+  const residentPassword = await bcrypt.hash('resident123', 10);
+
+  await prisma.building.create({
+    data: {
+      name: 'Demo Building',
+      address: '123 Main St',
+      tenantId: 1,
+      units: {
+        create: [
+          {
+            number: '1A',
+            residents: {
+              create: [
+                {
+                  user: {
+                    create: {
+                      email: 'resident1@demo.com',
+                      passwordHash: residentPassword,
+                      role: 'RESIDENT',
+                      tenantId: 1,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          {
+            number: '1B',
+            residents: {
+              create: [
+                {
+                  user: {
+                    create: {
+                      email: 'resident2@demo.com',
+                      passwordHash: residentPassword,
+                      role: 'RESIDENT',
+                      tenantId: 1,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  });
 }
 
 main().finally(async () => {

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './users/user.module';
+import { BuildingModule } from './buildings/building.module';
+import { UnitModule } from './units/unit.module';
 
 @Module({
-  imports: [AuthModule, UserModule],
+  imports: [AuthModule, UserModule, BuildingModule, UnitModule],
 })
 export class AppModule {}

--- a/apps/backend/src/buildings/building.controller.ts
+++ b/apps/backend/src/buildings/building.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Post, Body, Param, Put, Delete, UseGuards } from '@nestjs/common';
+import { BuildingService } from './building.service';
+import { CreateBuildingDto } from './dto/create-building.dto';
+import { UpdateBuildingDto } from './dto/update-building.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+
+@Controller('api/v1/buildings')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN, Role.PM)
+export class BuildingController {
+  constructor(private readonly buildings: BuildingService) {}
+
+  @Post()
+  create(@Body() dto: CreateBuildingDto) {
+    return this.buildings.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.buildings.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.buildings.findOne(+id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateBuildingDto) {
+    return this.buildings.update(+id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.buildings.remove(+id);
+  }
+}

--- a/apps/backend/src/buildings/building.module.ts
+++ b/apps/backend/src/buildings/building.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { BuildingService } from './building.service';
+import { BuildingController } from './building.controller';
+import { PrismaService } from '../prisma.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+
+@Module({
+  providers: [PrismaService, BuildingService, JwtAuthGuard, RolesGuard],
+  controllers: [BuildingController],
+})
+export class BuildingModule {}

--- a/apps/backend/src/buildings/building.service.ts
+++ b/apps/backend/src/buildings/building.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { Prisma, Building } from '@prisma/client';
+
+@Injectable()
+export class BuildingService {
+  constructor(private prisma: PrismaService) {}
+
+  create(data: Prisma.BuildingCreateInput): Promise<Building> {
+    return this.prisma.building.create({ data });
+  }
+
+  findAll(): Promise<Building[]> {
+    return this.prisma.building.findMany();
+  }
+
+  findOne(id: number): Promise<Building | null> {
+    return this.prisma.building.findUnique({ where: { id } });
+  }
+
+  update(id: number, data: Prisma.BuildingUpdateInput): Promise<Building> {
+    return this.prisma.building.update({ where: { id }, data });
+  }
+
+  remove(id: number): Promise<Building> {
+    return this.prisma.building.delete({ where: { id } });
+  }
+}

--- a/apps/backend/src/buildings/dto/create-building.dto.ts
+++ b/apps/backend/src/buildings/dto/create-building.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsString } from 'class-validator';
+
+export class CreateBuildingDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  address: string;
+
+  @IsInt()
+  tenantId: number;
+}

--- a/apps/backend/src/buildings/dto/update-building.dto.ts
+++ b/apps/backend/src/buildings/dto/update-building.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+
+export class UpdateBuildingDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @IsInt()
+  tenantId?: number;
+}

--- a/apps/backend/src/units/dto/create-unit.dto.ts
+++ b/apps/backend/src/units/dto/create-unit.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, IsInt, IsOptional, IsString } from 'class-validator';
+
+export class CreateUnitDto {
+  @IsString()
+  number: string;
+
+  @IsInt()
+  buildingId: number;
+
+  @IsOptional()
+  @IsArray()
+  residentIds?: number[];
+}

--- a/apps/backend/src/units/dto/update-unit.dto.ts
+++ b/apps/backend/src/units/dto/update-unit.dto.ts
@@ -1,0 +1,15 @@
+import { IsArray, IsInt, IsOptional, IsString } from 'class-validator';
+
+export class UpdateUnitDto {
+  @IsOptional()
+  @IsString()
+  number?: string;
+
+  @IsOptional()
+  @IsInt()
+  buildingId?: number;
+
+  @IsOptional()
+  @IsArray()
+  residentIds?: number[];
+}

--- a/apps/backend/src/units/unit.controller.ts
+++ b/apps/backend/src/units/unit.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Post, Body, Param, Put, Delete, UseGuards } from '@nestjs/common';
+import { UnitService } from './unit.service';
+import { CreateUnitDto } from './dto/create-unit.dto';
+import { UpdateUnitDto } from './dto/update-unit.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+
+@Controller('api/v1/units')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN, Role.PM)
+export class UnitController {
+  constructor(private readonly units: UnitService) {}
+
+  @Post()
+  create(@Body() dto: CreateUnitDto) {
+    const { residentIds, ...data } = dto;
+    return this.units.create(data, residentIds);
+  }
+
+  @Get()
+  findAll() {
+    return this.units.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.units.findOne(+id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateUnitDto) {
+    const { residentIds, ...data } = dto;
+    return this.units.update(+id, data, residentIds);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.units.remove(+id);
+  }
+}

--- a/apps/backend/src/units/unit.module.ts
+++ b/apps/backend/src/units/unit.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { UnitService } from './unit.service';
+import { UnitController } from './unit.controller';
+import { PrismaService } from '../prisma.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+
+@Module({
+  providers: [PrismaService, UnitService, JwtAuthGuard, RolesGuard],
+  controllers: [UnitController],
+})
+export class UnitModule {}

--- a/apps/backend/src/units/unit.service.ts
+++ b/apps/backend/src/units/unit.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { Prisma, Unit } from '@prisma/client';
+
+@Injectable()
+export class UnitService {
+  constructor(private prisma: PrismaService) {}
+
+  create(data: Prisma.UnitCreateInput, residentIds?: number[]): Promise<Unit> {
+    return this.prisma.unit.create({
+      data: {
+        ...data,
+        residents: residentIds
+          ? { connect: residentIds.map((id) => ({ id })) }
+          : undefined,
+      },
+    });
+  }
+
+  findAll(): Promise<Unit[]> {
+    return this.prisma.unit.findMany({ include: { residents: true } });
+  }
+
+  findOne(id: number): Promise<Unit | null> {
+    return this.prisma.unit.findUnique({
+      where: { id },
+      include: { residents: true },
+    });
+  }
+
+  update(id: number, data: Prisma.UnitUpdateInput, residentIds?: number[]): Promise<Unit> {
+    return this.prisma.unit.update({
+      where: { id },
+      data: {
+        ...data,
+        residents: residentIds
+          ? { set: residentIds.map((id) => ({ id })) }
+          : undefined,
+      },
+      include: { residents: true },
+    });
+  }
+
+  remove(id: number): Promise<Unit> {
+    return this.prisma.unit.delete({ where: { id } });
+  }
+}


### PR DESCRIPTION
## Summary
- add Prisma models for buildings, units and residents
- implement building and unit CRUD endpoints
- seed demo building with example units and residents

## Testing
- `npm test`
- `npm --workspace apps/backend test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a902ee341c83299236c4b1deda9436