### PR TITLE
feat: add dashboard reporting

### DIFF
--- a/Backlog.md
+++ b/Backlog.md
@@ -85,9 +85,9 @@
 
 **User Story:** כ–מנהל, אני רוצה לראות סטטוס כולל של תקלות ותשלומים.
 
-- [ ] Task 1: Build dashboard with KPIs (open tickets, SLA breaches, unpaid invoices).
-- [ ] Task 2: Add search/filter bar for quick lookup.
-- [ ] Task 3: Export CSV/Excel for accountant.
+- [x] Task 1: Build dashboard with KPIs (open tickets, SLA breaches, unpaid invoices).
+- [x] Task 2: Add search/filter bar for quick lookup.
+- [x] Task 3: Export CSV/Excel for accountant.
 
 **Acceptance:** מנהל רואה בלוח בקרה תמונה מלאה ומבצע חיתוכים לפי בניין/סטטוס.
 

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { TicketModule } from './tickets/ticket.module';
 import { WorkOrderModule } from './work-orders/work-order.module';
 import { PaymentModule } from './payments/payment.module';
 import { NotificationModule } from './notifications/notification.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { NotificationModule } from './notifications/notification.module';
     WorkOrderModule,
     PaymentModule,
     NotificationModule,
+    DashboardModule,
   ],
 })
 export class AppModule {}

--- a/apps/backend/src/dashboard/dashboard.controller.ts
+++ b/apps/backend/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+import { Response } from 'express';
+
+@Controller('api/v1/dashboard')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN, Role.PM, Role.ACCOUNTANT)
+export class DashboardController {
+  constructor(private dashboard: DashboardService) {}
+
+  @Get()
+  kpis(@Query('buildingId') buildingId?: string) {
+    return this.dashboard.kpis({ buildingId: buildingId ? +buildingId : undefined });
+  }
+
+  @Get('export')
+  async export(@Res() res: Response, @Query('buildingId') buildingId?: string) {
+    const csv = await this.dashboard.exportInvoices({ buildingId: buildingId ? +buildingId : undefined });
+    res.setHeader('Content-Type', 'text/csv');
+    res.send(csv);
+  }
+}

--- a/apps/backend/src/dashboard/dashboard.module.ts
+++ b/apps/backend/src/dashboard/dashboard.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService, PrismaService],
+})
+export class DashboardModule {}

--- a/apps/backend/src/dashboard/dashboard.service.ts
+++ b/apps/backend/src/dashboard/dashboard.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { TicketStatus, InvoiceStatus } from '@prisma/client';
+
+@Injectable()
+export class DashboardService {
+  constructor(private prisma: PrismaService) {}
+
+  async kpis(filter: { buildingId?: number }) {
+    const ticketFilter: any = { status: { not: TicketStatus.RESOLVED } };
+    if (filter.buildingId) {
+      ticketFilter.unit = { buildingId: filter.buildingId };
+    }
+    const slaFilter: any = {
+      status: { not: TicketStatus.RESOLVED },
+      slaDue: { lt: new Date() },
+    };
+    if (filter.buildingId) {
+      slaFilter.unit = { buildingId: filter.buildingId };
+    }
+    const invoiceFilter: any = { status: InvoiceStatus.UNPAID };
+    if (filter.buildingId) {
+      invoiceFilter.resident = { units: { some: { buildingId: filter.buildingId } } };
+    }
+    const [openTickets, slaBreaches, unpaidInvoices] = await Promise.all([
+      this.prisma.ticket.count({ where: ticketFilter }),
+      this.prisma.ticket.count({ where: slaFilter }),
+      this.prisma.invoice.count({ where: invoiceFilter }),
+    ]);
+    return { openTickets, slaBreaches, unpaidInvoices };
+  }
+
+  async exportInvoices(filter: { buildingId?: number }) {
+    const where: any = {};
+    if (filter.buildingId) {
+      where.resident = { units: { some: { buildingId: filter.buildingId } } };
+    }
+    const invoices = await this.prisma.invoice.findMany({ where });
+    const lines = [
+      'id,residentId,amount,status',
+      ...invoices.map((i) => `${i.id},${i.residentId},${i.amount},${i.status}`),
+    ];
+    return lines.join('\n');
+  }
+}

--- a/apps/frontend/pages/admin/dashboard.tsx
+++ b/apps/frontend/pages/admin/dashboard.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+interface Kpis {
+  openTickets: number;
+  slaBreaches: number;
+  unpaidInvoices: number;
+}
+
+export default function Dashboard() {
+  const [kpis, setKpis] = useState<Kpis>({ openTickets: 0, slaBreaches: 0, unpaidInvoices: 0 });
+  const [buildingId, setBuildingId] = useState('');
+
+  async function load() {
+    const query = buildingId ? `?buildingId=${buildingId}` : '';
+    const res = await fetch(`/api/v1/dashboard${query}`);
+    if (res.ok) {
+      setKpis(await res.json());
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, [buildingId]);
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <input
+        placeholder="Building ID"
+        value={buildingId}
+        onChange={(e) => setBuildingId(e.target.value)}
+      />
+      <div>Open Tickets: {kpis.openTickets}</div>
+      <div>SLA Breaches: {kpis.slaBreaches}</div>
+      <div>Unpaid Invoices: {kpis.unpaidInvoices}</div>
+      <a href={`/api/v1/dashboard/export${buildingId ? `?buildingId=${buildingId}` : ''}`}>
+        Export CSV
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build dashboard API with KPIs for tickets and invoices
- add admin dashboard page with filter and CSV export
- document completion of dashboard backlog tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a960dfe7b483299fc0006d28371c8e