### PR TITLE
docs: add frontend implementation tasks

### DIFF
--- a/Backlog.md
+++ b/Backlog.md
@@ -107,6 +107,19 @@
 
 ---
 
+## Epic: Frontend Implementation
+
+**User Story:** כ–משתמש, אני רוצה ממשק משתמש בעברית המכסה את כל הפונקציונליות כדי ליהנות מחוויית שימוש מקצועית.
+
+ - [ ] Task 1: Hebrew interface.
+ - [ ] Task 2: Include all system functionality.
+ - [ ] Task 3: Elegant & professional UI.
+ - [ ] Task 4: Enhanced user experience & engagement.
+
+**Acceptance:** משתמשים יכולים להפעיל את כל המערכת דרך ממשק עברי מקצועי וחוויתי.
+
+---
+
 ## Sprint Plan 
 
 - **Sprint 0**: Repo setup (monorepo, Next.js + NestJS, auth base, DB seed).


### PR DESCRIPTION
## Summary
- document frontend implementation epic with Hebrew interface and UX goals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a961cd02b08329bc4c4e46651f172b