### PR TITLE
feat: support master user impersonation

### DIFF
--- a/apps/backend/prisma/migrations/20231102000000_master_impersonation/migration.sql
+++ b/apps/backend/prisma/migrations/20231102000000_master_impersonation/migration.sql
@@ -1,0 +1,13 @@
+ALTER TYPE "Role" ADD VALUE IF NOT EXISTS 'MASTER';
+
+CREATE TABLE "ImpersonationEvent" (
+  "id" SERIAL PRIMARY KEY,
+  "masterUserId" INTEGER NOT NULL REFERENCES "User"("id"),
+  "action" TEXT NOT NULL,
+  "targetRole" "Role",
+  "tenantId" INTEGER,
+  "reason" TEXT,
+  "ip" TEXT,
+  "userAgent" TEXT,
+  "createdAt" TIMESTAMP DEFAULT NOW()
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -13,6 +13,7 @@ enum Role {
   TECH
   RESIDENT
   ACCOUNTANT
+  MASTER
 }
 
 enum TicketSeverity {
@@ -39,6 +40,7 @@ model User {
   resident      Resident?
   assignedTickets Ticket[] @relation("TicketAssignee")
   supplier      Supplier?
+  impersonationEvents ImpersonationEvent[] @relation("MasterEvents")
 }
 
 model Building {
@@ -114,4 +116,17 @@ model Invoice {
   amount     Float
   status     InvoiceStatus @default(UNPAID)
   createdAt  DateTime      @default(now())
+}
+
+model ImpersonationEvent {
+  id           Int      @id @default(autoincrement())
+  masterUserId Int
+  masterUser   User     @relation("MasterEvents", fields: [masterUserId], references: [id])
+  action       String
+  targetRole   Role?
+  tenantId     Int?
+  reason       String?
+  ip           String?
+  userAgent    String?
+  createdAt    DateTime @default(now())
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -20,6 +20,22 @@ async function main() {
     },
   });
 
+  const masterHash = await bcrypt.hash('master123', 10);
+  await prisma.user.upsert({
+    where: { email: 'master@demo.com' },
+    update: {
+      passwordHash: masterHash,
+      role: 'MASTER',
+      tenantId: 1,
+    },
+    create: {
+      email: 'master@demo.com',
+      passwordHash: masterHash,
+      role: 'MASTER',
+      tenantId: 1,
+    },
+  });
+
   await prisma.resident.deleteMany();
   await prisma.unit.deleteMany();
   await prisma.building.deleteMany();

--- a/apps/backend/src/admin/admin.controller.ts
+++ b/apps/backend/src/admin/admin.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { AdminService } from './admin.service';
+import { ImpersonateDto } from './dto/impersonate.dto';
+
+@Controller('admin')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AdminController {
+  constructor(private admin: AdminService) {}
+
+  @Post('impersonate')
+  @Roles(Role.MASTER)
+  impersonate(@Req() req: any, @Body() dto: ImpersonateDto) {
+    const ip = req.ip;
+    const userAgent = req.headers['user-agent'] || '';
+    return this.admin.impersonate(req.user, dto, ip, userAgent);
+  }
+
+  @Post('impersonate/stop')
+  @Roles(Role.MASTER)
+  stop(@Req() req: any) {
+    const ip = req.ip;
+    const userAgent = req.headers['user-agent'] || '';
+    return this.admin.stopImpersonation(req.user, ip, userAgent);
+  }
+}

--- a/apps/backend/src/admin/admin.module.ts
+++ b/apps/backend/src/admin/admin.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  imports: [
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'secret',
+    }),
+  ],
+  controllers: [AdminController],
+  providers: [AdminService, PrismaService],
+})
+export class AdminModule {}

--- a/apps/backend/src/admin/admin.service.ts
+++ b/apps/backend/src/admin/admin.service.ts
@@ -1,0 +1,69 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma.service';
+import { Role } from '@prisma/client';
+import { ImpersonateDto } from './dto/impersonate.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(private jwt: JwtService, private prisma: PrismaService) {}
+
+  async impersonate(user: any, dto: ImpersonateDto, ip: string, userAgent: string) {
+    if (dto.role === Role.MASTER || !Object.values(Role).includes(dto.role)) {
+      throw new BadRequestException('Invalid role');
+    }
+    const payload = {
+      sub: user.sub,
+      role: user.role,
+      actAsRole: dto.role,
+      tenantId: dto.tenantId,
+    };
+    const accessToken = await this.jwt.signAsync(payload, {
+      secret: process.env.JWT_SECRET || 'secret',
+      expiresIn: '30m',
+    });
+    const refreshToken = await this.jwt.signAsync(payload, {
+      secret: process.env.JWT_REFRESH_SECRET || 'refresh_secret',
+      expiresIn: '30m',
+    });
+    await this.prisma.impersonationEvent.create({
+      data: {
+        masterUserId: user.sub,
+        action: 'START',
+        targetRole: dto.role,
+        tenantId: dto.tenantId,
+        reason: dto.reason,
+        ip,
+        userAgent,
+      },
+    });
+    return { accessToken, refreshToken };
+  }
+
+  async stopImpersonation(user: any, ip: string, userAgent: string) {
+    const payload = {
+      sub: user.sub,
+      role: user.role,
+      tenantId: user.tenantId,
+    };
+    const accessToken = await this.jwt.signAsync(payload, {
+      secret: process.env.JWT_SECRET || 'secret',
+      expiresIn: '15m',
+    });
+    const refreshToken = await this.jwt.signAsync(payload, {
+      secret: process.env.JWT_REFRESH_SECRET || 'refresh_secret',
+      expiresIn: '7d',
+    });
+    await this.prisma.impersonationEvent.create({
+      data: {
+        masterUserId: user.sub,
+        action: 'STOP',
+        targetRole: user.actAsRole,
+        tenantId: user.tenantId,
+        ip,
+        userAgent,
+      },
+    });
+    return { accessToken, refreshToken };
+  }
+}

--- a/apps/backend/src/admin/dto/impersonate.dto.ts
+++ b/apps/backend/src/admin/dto/impersonate.dto.ts
@@ -1,0 +1,14 @@
+import { Role } from '@prisma/client';
+import { IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
+
+export class ImpersonateDto {
+  @IsEnum(Role)
+  role: Role;
+
+  @IsInt()
+  tenantId: number;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { WorkOrderModule } from './work-orders/work-order.module';
 import { PaymentModule } from './payments/payment.module';
 import { NotificationModule } from './notifications/notification.module';
 import { DashboardModule } from './dashboard/dashboard.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { DashboardModule } from './dashboard/dashboard.module';
     PaymentModule,
     NotificationModule,
     DashboardModule,
+    AdminModule,
   ],
 })
 export class AppModule {}

--- a/apps/backend/src/auth/__tests__/roles.guard.spec.ts
+++ b/apps/backend/src/auth/__tests__/roles.guard.spec.ts
@@ -1,0 +1,34 @@
+import { RolesGuard } from '../roles.guard';
+import { Reflector } from '@nestjs/core';
+import { Role } from '@prisma/client';
+import { ExecutionContext } from '@nestjs/common';
+
+describe('RolesGuard', () => {
+  function setup(user: any, required: Role[]) {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(required),
+    } as unknown as Reflector;
+    const guard = new RolesGuard(reflector);
+    const context = {
+      getHandler: () => ({}),
+      getClass: () => ({}),
+      switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    } as unknown as ExecutionContext;
+    return { guard, context };
+  }
+
+  it('allows user with matching role', () => {
+    const { guard, context } = setup({ role: Role.ADMIN }, [Role.ADMIN]);
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows master acting as role', () => {
+    const { guard, context } = setup({ role: Role.MASTER, actAsRole: Role.ADMIN }, [Role.ADMIN]);
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('denies when actAsRole mismatch', () => {
+    const { guard, context } = setup({ role: Role.MASTER, actAsRole: Role.TECH }, [Role.ADMIN]);
+    expect(guard.canActivate(context)).toBe(false);
+  });
+});

--- a/apps/backend/src/auth/roles.guard.ts
+++ b/apps/backend/src/auth/roles.guard.ts
@@ -16,6 +16,7 @@ export class RolesGuard implements CanActivate {
       return true;
     }
     const { user } = context.switchToHttp().getRequest();
-    return requiredRoles.includes(user?.role);
+    const role = user?.actAsRole ?? user?.role;
+    return requiredRoles.includes(role);
   }
 }

--- a/apps/frontend/components/Layout.tsx
+++ b/apps/frontend/components/Layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import React from 'react';
+import RoleSwitcher from './RoleSwitcher';
 
 interface Props {
   children: React.ReactNode;
@@ -16,6 +17,7 @@ export default function Layout({ children }: Props) {
         <Link href="/admin/dashboard">דשבורד מנהל</Link>
         <Link href="/tech/jobs">משימות טכנאי</Link>
       </nav>
+      <RoleSwitcher />
       <main className="container">{children}</main>
     </div>
   );

--- a/apps/frontend/components/RoleSwitcher.tsx
+++ b/apps/frontend/components/RoleSwitcher.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { getTokenPayload, startImpersonation, stopImpersonation } from '../lib/auth';
+
+const roles = ['ADMIN', 'PM', 'TECH', 'RESIDENT', 'ACCOUNTANT'];
+
+export default function RoleSwitcher() {
+  const [payload, setPayload] = useState<any | null>(null);
+  const [role, setRole] = useState('ADMIN');
+  const [tenantId, setTenantId] = useState(1);
+
+  useEffect(() => {
+    setPayload(getTokenPayload());
+  }, []);
+
+  async function handleImpersonate() {
+    await startImpersonation(role, tenantId);
+    setPayload(getTokenPayload());
+  }
+
+  async function handleStop() {
+    await stopImpersonation();
+    setPayload(getTokenPayload());
+  }
+
+  if (!payload || payload.role !== 'MASTER') return null;
+
+  if (payload.actAsRole) {
+    return (
+      <div style={{ background: '#fffae6', padding: 8, marginBottom: 8 }}>
+        צפייה כ–{payload.actAsRole}{' '}
+        <button onClick={handleStop}>חזור למשתמש המקורי</button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginBottom: 8 }}>
+      <select value={role} onChange={(e) => setRole(e.target.value)}>
+        {roles.map((r) => (
+          <option key={r} value={r}>
+            {r}
+          </option>
+        ))}
+      </select>
+      <input
+        type="number"
+        value={tenantId}
+        onChange={(e) => setTenantId(parseInt(e.target.value, 10))}
+        style={{ width: 60, marginLeft: 8 }}
+      />
+      <button onClick={handleImpersonate} style={{ marginLeft: 8 }}>
+        החלף תפקיד
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add MASTER role and impersonation events to schema
- implement admin endpoints for impersonation and stop, with audit logging
- add frontend role switcher UI

## Testing
- `npm test`
- `npm --workspace apps/backend test`


------
https://chatgpt.com/codex/tasks/task_e_68a97682e8248329b0926eef71af3487